### PR TITLE
Add Slack channel to community refs

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,7 @@
 
     <h3>The Community</h3>
     <ul>
+      <li><a href="https://drupalslack.herokuapp.com/"/>#opendrupal channel on Drupal slack</li>
       <li><a href="https://plus.google.com/communities/108420378799329411006">Google+ Community</a></li>
       <li><a href="http://groups.drupal.org/opendrupal">groups.drupal.org/opendrupal</a></li>
   </ul></div>


### PR DESCRIPTION
I doubt if the other two refs are still used, but let's discuss that seperately.