### PR TITLE
Disable the hardly used secondary menu to reduce the website clutter.

### DIFF
--- a/404.html
+++ b/404.html
@@ -33,11 +33,11 @@
               <li class="primary-menu__item"><a href="/pages/the_curriculum.html">The Curriculum</a></li>
               <li class="primary-menu__item"><a href="/lessons/lessons.html">Lessons</a></li>
             </ul>
-            <ul class="secondary-menu">
+            <!--<ul class="secondary-menu">
               <li class="secondary-menu__item"><a href="pages/drupal_training_programmes.html">Training Programmes</a></li>
               <li class="secondary-menu__item"><a href="">The Open Drupal VM</a></li>
               <li class="secondary-menu__item"><a href="">FAQs</a></li>
-            </ul>
+            </ul>-->
           </nav>
         </div>
       </div>

--- a/README.html
+++ b/README.html
@@ -33,11 +33,11 @@
               <li class="primary-menu__item"><a href="/pages/the_curriculum.html">The Curriculum</a></li>
               <li class="primary-menu__item"><a href="/lessons/lessons.html">Lessons</a></li>
             </ul>
-            <ul class="secondary-menu">
+            <!--<ul class="secondary-menu">
               <li class="secondary-menu__item"><a href="pages/drupal_training_programmes.html">Training Programmes</a></li>
               <li class="secondary-menu__item"><a href="">The Open Drupal VM</a></li>
               <li class="secondary-menu__item"><a href="">FAQs</a></li>
-            </ul>
+            </ul>-->
           </nav>
         </div>
       </div>

--- a/bootcamp/bootcamp.html
+++ b/bootcamp/bootcamp.html
@@ -34,11 +34,11 @@
               <li class="primary-menu__item"><a href="/lessons/lessons.html">Lessons</a></li>
               <li class="primary-menu__item"><a href="/lessons/bootcamp.html">Bootcamp</a></li>
             </ul>
-            <ul class="secondary-menu">
+            <!--<ul class="secondary-menu">
               <li class="secondary-menu__item"><a href="pages/drupal_training_programmes.html">Training Programmes</a></li>
               <li class="secondary-menu__item"><a href="">The Open Drupal VM</a></li>
               <li class="secondary-menu__item"><a href="">FAQs</a></li>
-            </ul>
+            </ul>-->
           </nav>
         </div>
       </div>
@@ -48,96 +48,96 @@
 
   <nav class="lessons__nav grid-item">
     <ul class="lessons__tabs tabs vertical" data-tab data-options="deep_linking:true">
-      
+
         <li class="tab-title active">
           <a href="#overview">Overview</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#intro">1. Intro</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#html">2. Hello world - HTML</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#cms">3. Content Management Systems</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#drupal">4. What is Drupal?</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#setup">5. Set up your first Drupal site</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#manage">6. Manage your Drupal site</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#customise">7. Customise your Drupal site</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#theme">8. Change the theme</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#homepage">9. Dynamic Pages &amp; Homepage</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#about">10. Add an about me page</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#contact">11. Add a custom contact form</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#local">12. Set up locally</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#import">13. Rebuild &amp; Import</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#cke">14. Improve the editing experience</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#subtheme">15. Creating your own theme</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#users">16. Working with users</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#extramodules">17. Extra modules</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#community">18. The Drupal Community</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#resources">19. Resources</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#projects">20. Projects</a>
         </li>
-      
+
     </ul>
   </nav>
 
   <div class="lessons__content tabs-content grid-item">
-    
+
       <div class="lesson content active" id="overview">
         <h1>Open Drupal Bootcamp</h1>
         <p class="intro"><h2>What will I learn about? </h2>
@@ -165,7 +165,7 @@
         </ul>
 
       </div>
-    
+
       <div class="lesson content" id="intro">
         <h2>1. Introduction</h2>
         <p class="intro"><strong>What&rsquo;s in this module?</strong> An introduction to the course and getting setup on correct systems.</p>
@@ -195,7 +195,7 @@
         </ul>
 
       </div>
-    
+
       <div class="lesson content" id="html">
         <h2>Manchester Bootcamp - skip this one :)</h2>
         <h3>What we&rsquo;ll be doing</h3>
@@ -217,7 +217,7 @@
         </ul>
 
       </div>
-    
+
       <div class="lesson content" id="cms">
         <h2>3. Content Management Systems</h2>
         <h3>Why a CMS?</h3>
@@ -235,7 +235,7 @@
         <p><strong>Read:</strong> <a href="http://visual.ly/junk-trunk%20">Wordpress vs Drupal vs Joomla infographic</a></p>
 
       </div>
-    
+
       <div class="lesson content" id="drupal">
         <h2>4. What is Drupal?</h2>
         <h3>Drupal overview</h3>
@@ -270,10 +270,10 @@
         <li><a href="http://drupal.stackexchange.com/">Drupal Answers</a> - An excellent resource for technical questions around Drupal</li>
         <li><a href="https://www.google.co.uk/search?q=what+is+drupal">Search: What is Drupal</a> - There&rsquo;s loads of information about Drupal out there!</li>
         </ul>
-  
+
 
       </div>
-    
+
       <div class="lesson content" id="setup">
         <h2>5. Set up your Drupal site</h2>
         <h3>A. What we&rsquo;ll be doing</h3>
@@ -293,7 +293,7 @@
         </ul>
 
       </div>
-    
+
       <div class="lesson content" id="manage">
         <h2>6. Manage your site</h2>
         <h3>A. Nodes</h3>
@@ -360,10 +360,10 @@
         <ul>
         <li><strong>Taxonomy: </strong><a href="http://nodeone.se/en/adding-product-categories">NodeOne: Adding product categories</a></li>
         </ul>
-  
+
 
       </div>
-    
+
       <div class="lesson content" id="customise">
         <h2>7. Customise your site</h2>
         <h3>Add a slogan</h3>
@@ -397,10 +397,10 @@
         <li><strong>Watch:</strong> <a href="about:blank">Drupal Tutorials - An Introduction to Blocks</a></li>
         <li><strong>Read:</strong> <a href="http://www.inmotionhosting.com/support/edu/drupal-7/blocks-and-regions/create-block%20">Creating a block</a></li>
         </ul>
-  
+
 
       </div>
-    
+
       <div class="lesson content" id="theme">
         <h2>8. Change the theme</h2>
         <h3>Drupal Themes</h3>
@@ -431,7 +431,7 @@
         </ul>
 
       </div>
-    
+
       <div class="lesson content" id="homepage">
         <h2>9. Dynamic Pages &amp; Homepage</h2>
         <h3>A. Modules</h3>
@@ -466,10 +466,10 @@
         <li><strong>Read:</strong> <a href="http://www.templatemonster.com/help/drupal-7-how-to-use-views-module-and-editconfigure-it.html">Views tutorial</a></li>
         </ul>
         <strong><strong>Read:</strong> <a href="http://www.drupalgardens.com/documentation/views/tutorial">Views tutorial</a> (Drupal Gardens)</strong>
-          
+
 
       </div>
-    
+
       <div class="lesson content" id="about">
         <h2>10. Make a custom About Me page</h2>
         <h3>A. Create the page and add some content</h3>
@@ -491,7 +491,7 @@
 
       </div>
 
-    
+
       <div class="lesson content" id="contact">
         <h2>11. Add a custom contact form</h2>
         <h3>A. Creating the webform node</h3>
@@ -721,9 +721,9 @@
         <p>Choose a project from the list, they all contain a brief, some hints and tips to help you get started and extra resources.</p>
         <p>The projects are stored on Google drive here: <a href="http://bit.ly/ODprojects">http://bit.ly/ODprojects</a>
 
-      </div>  
- 
-    
+      </div>
+
+
   </div>
 
 </div>

--- a/index.html
+++ b/index.html
@@ -33,11 +33,11 @@
               <li class="primary-menu__item"><a href="/pages/the_curriculum.html">The Curriculum</a></li>
               <li class="primary-menu__item"><a href="/lessons/lessons.html">Lessons</a></li>
             </ul>
-            <ul class="secondary-menu">
+            <!--<ul class="secondary-menu">
               <li class="secondary-menu__item"><a href="pages/drupal_training_programmes.html">Training Programmes</a></li>
               <li class="secondary-menu__item"><a href="">The Open Drupal VM</a></li>
               <li class="secondary-menu__item"><a href="">FAQs</a></li>
-            </ul>
+            </ul>-->
           </nav>
         </div>
       </div>

--- a/lessons/lessons.html
+++ b/lessons/lessons.html
@@ -33,11 +33,11 @@
               <li class="primary-menu__item"><a href="/pages/the_curriculum.html">The Curriculum</a></li>
               <li class="primary-menu__item"><a href="/lessons/lessons.html">Lessons</a></li>
             </ul>
-            <ul class="secondary-menu">
+            <!--<ul class="secondary-menu">
               <li class="secondary-menu__item"><a href="pages/drupal_training_programmes.html">Training Programmes</a></li>
               <li class="secondary-menu__item"><a href="">The Open Drupal VM</a></li>
               <li class="secondary-menu__item"><a href="">FAQs</a></li>
-            </ul>
+            </ul>-->
           </nav>
         </div>
       </div>
@@ -47,42 +47,42 @@
 
   <nav class="lessons__nav grid-item">
     <ul class="lessons__tabs tabs vertical" data-tab data-options="deep_linking:true">
-      
+
         <li class="tab-title active">
           <a href="#overview">Overview</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#toolchain1">Toolchain Pt. 1</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#toolchain2">Toolchain Pt. 2</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#site-building-front-end">Site Building &amp; Front End Development</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#team1">Agile Development</a>
         </li>
-      
+
         <li class="tab-title">
           <a href="#frontend1">Front End Development Pt. 1</a>
         </li>
-      
+
     </ul>
   </nav>
 
   <div class="lessons__content tabs-content grid-item">
-    
+
       <div class="lesson content active" id="overview">
         <p>  <h1>Open Drupal Lessons</h1>
   </p><p class="intro">Here you can find a number of lessons available for teaching Drupal, they all follow a one day workshop style. The lessons themselves provide information, resources and exercises to work through. When delivered by a trainer they should always be supplemented with instruction, discussions, demos etc. The lessons can also be followed by an individual self-learning.</p><p>There are some accompanying notes with lessons which can be used as ideas for delivery for trainers.</p>
 
       </div>
-    
+
       <div class="lesson content" id="toolchain1">
         <h2>Project Setup &amp; Intro to the Toolchain</h2><h1>Overview</h1><ul>
 <li>Deciding on a project to work on over the coming workshops, so there is a consistent focus and so you can build something useful and use as evidence.</li>
@@ -143,7 +143,7 @@
 </ul>
 
       </div>
-    
+
       <div class="lesson content" id="toolchain2">
         <h2>The Toolchain Continued &amp; Site Building</h2><h1>Project Build</h1><h3>A. Start building your site</h3><ul>
 <li>Start building your site by downloading contrib modules you think you&#39;ll need, create some content types and add some test content.</li>
@@ -211,7 +211,7 @@
 </ul>
 
       </div>
-    
+
       <div class="lesson content" id="site-building-front-end">
         <h2>Site Building &amp; Front End Development</h2><h1>Overview</h1><p>A look into the Drupal contrib module ecosystem, install some useful modules to assist with development and dive deeper into a few powerful modules relevant to your project. Then spend some time going over the frontend development landscape and start building a theme in Drupal, learning about subtheming and getting started with Sass.</p>
 <p>After this lesson you should have:</p>
@@ -316,7 +316,7 @@
 </ul>
 
       </div>
-    
+
       <div class="lesson content" id="team1">
         <h2>Agile Development</h2><p>@todo - Add in Crispin&#39;s notes.</p>
 <p>This lesson contains an introduction to the concepts of Agile development. This includes the general theory behind agile teams and the agile lifecycle as well as the more specific methdology of Scrum.</p>
@@ -356,7 +356,7 @@
 </ul>
 
       </div>
-    
+
       <div class="lesson content" id="frontend1">
         <h2>Frontend Development &amp; Theming in Drupal</h2><h1>HTML &amp; Templating</h1><p>Aims: Be able to write well structured, semantic HTML. Understand Drupal&#39;s theme system, override template and theme functions.</p>
 <h3>A. HTML 5</h3><ul>
@@ -422,7 +422,7 @@
 </ul>
 
       </div>
-    
+
   </div>
 
 </div>

--- a/pages/drupal_training_programmes.html
+++ b/pages/drupal_training_programmes.html
@@ -33,11 +33,11 @@
               <li class="primary-menu__item"><a href="/pages/the_curriculum.html">The Curriculum</a></li>
               <li class="primary-menu__item"><a href="/lessons/lessons.html">Lessons</a></li>
             </ul>
-            <ul class="secondary-menu">
+            <!--<ul class="secondary-menu">
               <li class="secondary-menu__item"><a href="pages/drupal_training_programmes.html">Training Programmes</a></li>
               <li class="secondary-menu__item"><a href="">The Open Drupal VM</a></li>
               <li class="secondary-menu__item"><a href="">FAQs</a></li>
-            </ul>
+            </ul>-->
           </nav>
         </div>
       </div>

--- a/pages/the_curriculum.html
+++ b/pages/the_curriculum.html
@@ -33,11 +33,11 @@
               <li class="primary-menu__item"><a href="/pages/the_curriculum.html">The Curriculum</a></li>
               <li class="primary-menu__item"><a href="/lessons/lessons.html">Lessons</a></li>
             </ul>
-            <ul class="secondary-menu">
+            <!--<ul class="secondary-menu">
               <li class="secondary-menu__item"><a href="pages/drupal_training_programmes.html">Training Programmes</a></li>
               <li class="secondary-menu__item"><a href="">The Open Drupal VM</a></li>
               <li class="secondary-menu__item"><a href="">FAQs</a></li>
-            </ul>
+            </ul>-->
           </nav>
         </div>
       </div>

--- a/sass/README.html
+++ b/sass/README.html
@@ -33,63 +33,63 @@
               <li class="primary-menu__item"><a href="/pages/the_curriculum.html">The Curriculum</a></li>
               <li class="primary-menu__item"><a href="/lessons/lessons.html">Lessons</a></li>
             </ul>
-            <ul class="secondary-menu">
-              <li class="secondary-menu__item"><a href="pages/drupal_training_programmes.html">Training Programmes</a></li>
-              <li class="secondary-menu__item"><a href="">The Open Drupal VM</a></li>
-              <li class="secondary-menu__item"><a href="">FAQs</a></li>
-            </ul>
-          </nav>
-        </div>
-      </div>
-    </header>
+            <!-- <ul class="secondary-menu">
+               <li class="secondary-menu__item"><a href="pages/drupal_training_programmes.html">Training Programmes</a></li>
+               <li class="secondary-menu__item"><a href="">The Open Drupal VM</a></li>
+               <li class="secondary-menu__item"><a href="">FAQs</a></li>
+             </ul>-->
+           </nav>
+         </div>
+       </div>
+     </header>
 
-<h2>Rocket CSS</h2><p><a href="https://github.com/hedleysmith/rocketcss">Rocket CSS</a> is a decoupled library of CSS components written using Sass.</p>
-<p>Components are provided with some styling and configuration options but are designed to be used as a starting point in a custom design system.</p>
-<p>Rocket also encourages the use of components from other libraries.</p>
-<h3>Customising Components</h3><p>It&#39;s up to you how you customise the components. Here are two suggested approaches</p>
-<p>1) <strong>Use Rocket components as a starting point.</strong> Go in and edit the component code directly, useful for larger projects where you&#39;re likely to deviate significantly from the original component and you want to have more control. A disadvantage of this is that if there are updates released for a component it&#39;ll be more difficult to take advantages of these.</p>
-<p>2) <strong>Configure and extend components.</strong> By keeping the original Rocket component you&#39;ll be able to take advantage of any updates that are released. Each component has a number of default configuration options documented at the start of the component file, these can be overridden elsewhere in the codebase. You could add your own customisations to a _theme.scss file which should be included before the component.</p>
-<h2>Importing Components</h2><p>With numerous front end component libraries out there it makes sense to harness them. Rocket provides a way to use and customise individual components from other libraries without having to follow their design patterns entirely.</p>
-<h3>Foundation</h3><p><strong>Installation</strong></p>
-<ol>
-<li>Copy _functions.scss and _global.scss across.</li>
-<li>Copy over the .scss file for the component you&#39;re installing.</li>
-<li>Now attempt to compile the codebase, if there are any missing dependencies, figure out how to resolve them (this part can get a bit tricky).</li>
-</ol>
-<p><strong>Javascript Components</strong></p>
-<ol>
-<li>Foundation <a href="http://foundation.zurb.com/docs/javascript.html">requires Modernizr &amp; jQuery &gt; 2.1.0</a> so include these as well as foundation.js - also, initialise foundation.</li>
-</ol>
-<pre><code>&lt;script src=&quot;//cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js&quot;&gt;&lt;/script&gt;
-&lt;script src=&quot;//code.jquery.com/jquery-2.1.4.min.js&quot;&gt;&lt;/script&gt;
-&lt;script src=&quot;/js/foundation.js&quot;&gt;&lt;/script&gt;
-&lt;script&gt;
-  $(document).foundation();
-&lt;/script&gt;
-</code></pre><ol>
-<li>Copy the relevant .js file, e.g /js/foundation.tab.js</li>
-</ol>
-<h3>Bootstrap</h3><p>@todo</p>
-<h3>Material Design Light</h3><p>@todo</p>
-<h3>Other Libraries</h3><ul>
-<li><a href="http://expandjs.com/">ExpandJS</a></li>
-</ul>
-  <footer class="footer l-container">
-    <div class="footer__inner">
-      <p><a href="https://github.com/opendrupal">Find us on GitHub</a></p>
-    </div>
-  </div>
+ <h2>Rocket CSS</h2><p><a href="https://github.com/hedleysmith/rocketcss">Rocket CSS</a> is a decoupled library of CSS components written using Sass.</p>
+ <p>Components are provided with some styling and configuration options but are designed to be used as a starting point in a custom design system.</p>
+ <p>Rocket also encourages the use of components from other libraries.</p>
+ <h3>Customising Components</h3><p>It&#39;s up to you how you customise the components. Here are two suggested approaches</p>
+ <p>1) <strong>Use Rocket components as a starting point.</strong> Go in and edit the component code directly, useful for larger projects where you&#39;re likely to deviate significantly from the original component and you want to have more control. A disadvantage of this is that if there are updates released for a component it&#39;ll be more difficult to take advantages of these.</p>
+ <p>2) <strong>Configure and extend components.</strong> By keeping the original Rocket component you&#39;ll be able to take advantage of any updates that are released. Each component has a number of default configuration options documented at the start of the component file, these can be overridden elsewhere in the codebase. You could add your own customisations to a _theme.scss file which should be included before the component.</p>
+ <h2>Importing Components</h2><p>With numerous front end component libraries out there it makes sense to harness them. Rocket provides a way to use and customise individual components from other libraries without having to follow their design patterns entirely.</p>
+ <h3>Foundation</h3><p><strong>Installation</strong></p>
+ <ol>
+ <li>Copy _functions.scss and _global.scss across.</li>
+ <li>Copy over the .scss file for the component you&#39;re installing.</li>
+ <li>Now attempt to compile the codebase, if there are any missing dependencies, figure out how to resolve them (this part can get a bit tricky).</li>
+ </ol>
+ <p><strong>Javascript Components</strong></p>
+ <ol>
+ <li>Foundation <a href="http://foundation.zurb.com/docs/javascript.html">requires Modernizr &amp; jQuery &gt; 2.1.0</a> so include these as well as foundation.js - also, initialise foundation.</li>
+ </ol>
+ <pre><code>&lt;script src=&quot;//cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js&quot;&gt;&lt;/script&gt;
+ &lt;script src=&quot;//code.jquery.com/jquery-2.1.4.min.js&quot;&gt;&lt;/script&gt;
+ &lt;script src=&quot;/js/foundation.js&quot;&gt;&lt;/script&gt;
+ &lt;script&gt;
+   $(document).foundation();
+ &lt;/script&gt;
+ </code></pre><ol>
+ <li>Copy the relevant .js file, e.g /js/foundation.tab.js</li>
+ </ol>
+ <h3>Bootstrap</h3><p>@todo</p>
+ <h3>Material Design Light</h3><p>@todo</p>
+ <h3>Other Libraries</h3><ul>
+ <li><a href="http://expandjs.com/">ExpandJS</a></li>
+ </ul>
+   <footer class="footer l-container">
+     <div class="footer__inner">
+       <p><a href="https://github.com/opendrupal">Find us on GitHub</a></p>
+     </div>
+   </div>
 
-  <script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-4f5b704772f91b81"></script>
+   <script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-4f5b704772f91b81"></script>
 
-    <script src="//code.jquery.com/jquery-2.1.4.min.js"></script>
+     <script src="//code.jquery.com/jquery-2.1.4.min.js"></script>
 
-    <script src="/js/foundation.js"></script>
-    <script src="/js/foundation.tab.js"></script>
+     <script src="/js/foundation.js"></script>
+     <script src="/js/foundation.tab.js"></script>
 
-    <script>
-      $(document).foundation();
-    </script>
-  </body>
-</html>
+     <script>
+       $(document).foundation();
+     </script>
+   </body>
+ </html>
 


### PR DESCRIPTION
This might be a bit controversial. The secondary menu is currently only used for 'Training programmes', the other links are dead.

I propose to remove the links for now, to minimise the clutter at this moment and later discuss the usage of these links and the site structure in a wider perspective.